### PR TITLE
net leader init fix, + internal stuff

### DIFF
--- a/SteaSummon.toc
+++ b/SteaSummon.toc
@@ -2,7 +2,7 @@
 ## Title: SteaSummon
 ## Notes: One button summoning, shared summoning list...
 ## Author: Stea
-## Version: 0.5
+## Version: 0.51
 ## SavedVariablesPerCharacter: SteaSummonSave, SteaDEBUG
 
 Libs\embeds.xml

--- a/events.lua
+++ b/events.lua
@@ -90,6 +90,7 @@ function loaded(_, event, ...)
     -- otherwise the category or its children may not be registered for chat debug messages
     addonData.debug:chatCat("summon.waitlist")
     addonData.debug:chatCat("gossip")
+    addonData.debug:chatCat("buffs")
     addonData.debug:chatCatSwitch(true) -- strictly this is unnecessary, but I want to see the output
 
     cprint("loaded")

--- a/main.lua
+++ b/main.lua
@@ -6,8 +6,12 @@
 -- TODO: add type down search of list
 -- TODO: add fancy spell casting next button
 -- TODO: add sound when next button pops
--- TODO: L10N **** Prio
--- TODO: key bindings
+-- TODO: offline on alt support
+-- TODO: better offline, dead/ghost checks - dont need to enumerate raid for that, just the list
+-- TODO: raid lead/assist function
+-- TODO: nag for assist
+-- TODO: auto life tap, maybe eat/drink too?
+-- TODO: party/raid confirmation of add
 
 -- notes:
 --
@@ -16,7 +20,7 @@
 -- gold ring (minimap frame button): ../COMMON/BlueMenuRing.png
 -- gold ring (minimap looks closer): ../COMMON/RingBorder
 -- gold ring: ../COMMON/GoldRing
--- indicators (round): ../COMMON/inicator-(Red,Yellow,Gray,Green)
+-- indicators (round): ../COMMON/idnicator-(Red,Yellow,Gray,Green)
 -- button fram UI-Quickslot /-Depress
 -- sound: RAID_WARNING = 8959,
 

--- a/monitor.lua
+++ b/monitor.lua
@@ -2,16 +2,22 @@
 
 local _, addonData = ...
 
+local LONG_TIME = 2
+local SHORT_TIME = 0.2
+local SECOND_TIME = 1
+
 local monitor = {
-  sec_t = {},
+  second_t = {},
+  short_t = {},
   long_t = {},
 
   init = function(self)
     addonData.debug:registerCategory("monitor")
-    self.sec_t = self:create(1, self.callback_sec)
-    self.long = self:create(2, self.callback_long)
+    self.short_t = self:create(SHORT_TIME, self.callback_short)
+    self.long_t = self:create(LONG_TIME, self.callback_long)
+    self.second_t = self:create(SECOND_TIME, self.callback_sec)
     self:start()
-    self.long:Play()
+    self.long_t:Play()
   end,
 
   create = function(_, i, callback, timerRepeat)
@@ -39,15 +45,21 @@ local monitor = {
   end,
 
   start = function(self)
-    self.sec_t:Play()
+    self.short_t:Play()
+    self.second_t:Play()
   end,
 
   stop = function(self)
-    self.sec_t:Stop()
+    self.short_t:Stop()
+    self.second_t:Stop()
+  end,
+
+  callback_short = function()
+    addonData.summon:tick()
   end,
 
   callback_sec = function()
-    addonData.summon:tick()
+    addonData.summon:timerSecondTick()
   end,
 
   callback_long = function()

--- a/util.lua
+++ b/util.lua
@@ -91,6 +91,7 @@ local util = {
     end
     addonData.summon.waiting = waiting
     addonData.summon.numwaiting = numwaiting
+    addonData.summon:listDirty(true)
   end,
 
   sortWaitingTableByTime = function()
@@ -99,10 +100,10 @@ local util = {
     end)
   end,
 
-  isInTable = function(self, tbl, item)
+  isInTable = function(_, tbl, item)
     local inTable = false
 
-    for i,v in pairs(tbl) do
+    for _,v in pairs(tbl) do
       if v == item then
         inTable = true
         break


### PR DESCRIPTION
Fixed bug where the leader needing a waiting list would ignore a waiting list because it wasnt sent from the leader.

Decoupled time updates from other visual updates and made visual responses to state changes faster but only happen when the state has changed. Should reduce load while also increasing visual response.

Made offline and dead checks just in time.

Added offline checks when something a net leader should do is about to happen.