### PR TITLE
Bug fix, a few net changes

### DIFF
--- a/Locale/enUS.lua
+++ b/Locale/enUS.lua
@@ -102,4 +102,4 @@ L["version: %v\nbuild: %b\ndate: %d\ntocversion: %t\n\nSteaSummon version %s"] =
 
 -- gossip.lua
 L["There is a newer version available."] = true
-L["version"] = "Your version of SteaSummon has an old network protocol version. You really should update and restart your client now."
+L["version"] = "Network communications is disabled. Your version of SteaSummon has an old network protocol version. You should update and restart your client now."

--- a/SteaSummon.toc
+++ b/SteaSummon.toc
@@ -2,9 +2,9 @@
 ## Title: SteaSummon
 ## Notes: One button summoning, shared summoning list...
 ## Author: Stea
-## Version: 0.53
+## Version: 0.54
 ## SavedVariablesPerCharacter: SteaSummonSave, SteaDEBUG
-## x-SteaSummon-Protocol-version: 0.1
+## x-SteaSummon-Protocol-version: 0.2
 
 Libs\embeds.xml
 Locale\Locales.xml

--- a/monitor.lua
+++ b/monitor.lua
@@ -3,7 +3,7 @@
 local _, addonData = ...
 
 local LONG_TIME = 2
-local SHORT_TIME = 0.2
+local SHORT_TIME = 0.5
 local SECOND_TIME = 1
 
 local monitor = {


### PR DESCRIPTION
Made network code a little more idempotent.

Added replay of events that occur during init but the state is not there to act on. Removed timer to wait for a leader to emerge, since replay makes that bodge unecessary.

Added more protective code around frames that were assumed to always exist, but it turns out asynchronicity has a way of changing that.

Pruned the raid code of all the info collection it turned out was not needed or there was a better way to get at it.

Fixed protocol around destination and at destination to maintain the at dest list properly, there was also a bug around

Caught some places that operated on the waiting table directly and funnelled them through existing methods, or created them.

Made the disconnect message clear that its disconnecting the client from the addon network.

Simplified protocol around destination now that more rigorous checks are made before reporting.